### PR TITLE
Added LD-Relay service

### DIFF
--- a/dock
+++ b/dock
@@ -35,17 +35,17 @@ fi
 
 if [ $1 == "build" ]
 then
-    docker-compose build $2
+    docker-compose -f docker-compose.override.yml -f docker-compose.yml build $2
 fi
 
 if [ $1 == "rebuild" ]
 then
-    docker-compose build --no-cache $2
+    docker-compose -f docker-compose.override.yml -f docker-compose.yml build --no-cache $2
 fi
 
 if [ $1 == "up" ]
 then
-    docker-compose up -d nginx mysql redis workspace 
+    docker-compose -f docker-compose.override.yml -f docker-compose.yml up -d nginx mysql redis workspace ld-relay
 fi
 
 if [ $1 == "down" ]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  ld-relay:
+    image: "launchdarkly/ld-relay:latest"
+    environment:
+      - LD_ENV_local=${LD_RELAY_KEY}
+      - USE_REDIS=true
+      - REDIS_HOST=redis
+    ports:
+      - "8030:8030"
+    networks:
+      - backend


### PR DESCRIPTION
ld-relay supports our LaunchDarkly feature flag infrastructure (its an additional container running the required software to cache feature flags from the service)

things to note:
- according to the docker docs, docker-compose.override.yml should be read automatically - but for some reason it is not - so if added it to the dock up commands (this sucks, but i have no idea what its not reading it as per their docs)
- you will need to add 
```
### LD_RELAY ###############################################

LD_RELAY_KEY=sdk-9742b0a5-3abd-4c19-aacc-4c91700fe846
```

to your humidock .env file